### PR TITLE
Fallback to HTTP when HTTPS redirects to blocked host

### DIFF
--- a/BulkFillForm/parallelDomainCheck.py
+++ b/BulkFillForm/parallelDomainCheck.py
@@ -49,11 +49,14 @@ def check_domain(domain):
             if original_domain in final_domain and not any(b in final_domain for b in BLOCKED_HOSTS):
                 print(f"{domain} - ✅ Active and not redirected to marketplace")
                 return domain
-            else:
-                print(f"{domain} - ⚠️ Redirected to {final_domain}, skipping")
-                return None
+            if any(b in final_domain for b in BLOCKED_HOSTS):
+                print(f"{domain} - ⚠️ Redirected to {final_domain}, trying next scheme")
+                continue
+            print(f"{domain} - ⚠️ Redirected to {final_domain}, skipping")
+            return None
         except requests.exceptions.RequestException as e:
             print(f"{domain} - ❌ Request failed - {e}")
+            continue
     return None
 
 # === Function to write results from queue to CSV ===


### PR DESCRIPTION
## Summary
- Continue domain checking with HTTP if HTTPS request fails or points to a blocked marketplace

## Testing
- `python -m py_compile BulkFillForm/parallelDomainCheck.py`


------
https://chatgpt.com/codex/tasks/task_b_68aee2853e1c8330990565608f05dd3f